### PR TITLE
Support passing of arbitrary name=value pairs to the --set argument to whenever

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,12 @@ in `deploy.rb`
 These are the settings you can set:
 
     set :whenever_name # default: "#{domain}_#{rails_env}"
+    
+You can also pass arbitrary key / value pairs to Whenever for use in the `schedule.rb` file via `whenever_sets`.
+
+    set :whenever_sets, our_host: ENV['HOST']                      
+
+In this way you can access the value via the `@our_host` variable in `schedule.rb`.
 
 ## Contributing
 

--- a/lib/mina/whenever/tasks.rb
+++ b/lib/mina/whenever/tasks.rb
@@ -1,11 +1,25 @@
 set :whenever_name, -> { "#{fetch(:domain)}_#{fetch(:rails_env)}" }
 
 namespace :whenever do
+
+  # ### whenever_sets
+  # Pass optional name=value pairs to the --set argument of whenever.
+  # Specify these in your deploy.rb as key/value pairs, for example:
+  #     set :whenever_sets, host: ENV['HOST']
+
+  sets = lambda { whenever_sets || {} }
+
+  set_string = lambda do
+    ["environment=#{fetch(:rails_env)}",
+     "path=#{fetch(:current_path)}",
+     sets.call.map { |k, v| "#{k}=#{v}" }].flatten.join('&')
+  end
+
   desc 'Clear crontab'
   task clear: :environment do
     comment "Clear contrab for #{fetch(:whenever_name)}"
     in_path fetch(:current_path) do
-      command "#{fetch(:bundle_bin)} exec whenever --clear-crontab #{fetch(:whenever_name)} --set 'environment=#{fetch(:rails_env)}&path=#{fetch(:current_path)}'"
+      command "#{fetch(:bundle_bin)} exec whenever --clear-crontab #{fetch(:whenever_name)} --set '#{set_string.call}'"
     end
   end
 
@@ -13,7 +27,7 @@ namespace :whenever do
   task update: :environment do
     comment "Update crontab for #{fetch(:whenever_name)}"
     in_path fetch(:current_path) do
-      command "#{fetch(:bundle_bin)} exec whenever --update-crontab #{fetch(:whenever_name)} --set 'environment=#{fetch(:rails_env)}&path=#{fetch(:current_path)}'"
+      command "#{fetch(:bundle_bin)} exec whenever --update-crontab #{fetch(:whenever_name)} --set '#{set_string.call}'"
     end
   end
 
@@ -21,7 +35,7 @@ namespace :whenever do
   task write: :environment do
     comment "Write crontab for #{fetch(:whenever_name)}"
     in_path fetch(:current_path) do
-      command "#{fetch(:bundle_bin)} exec whenever --write-crontab #{fetch(:whenever_name)} --set 'environment=#{fetch(:rails_env)}&path=#{fetch(:current_path)}'"
+      command "#{fetch(:bundle_bin)} exec whenever --write-crontab #{fetch(:whenever_name)} --set '#{set_string.call}'"
     end
   end
 end

--- a/lib/mina/whenever/tasks.rb
+++ b/lib/mina/whenever/tasks.rb
@@ -7,7 +7,7 @@ namespace :whenever do
   # Specify these in your deploy.rb as key/value pairs, for example:
   #     set :whenever_sets, host: ENV['HOST']
 
-  sets = lambda { whenever_sets || {} }
+  sets = lambda { fetch(:whenever_sets) || {} }
 
   set_string = lambda do
     ["environment=#{fetch(:rails_env)}",


### PR DESCRIPTION
This allows passing of arbitrary values into whenever via the --set facility.

```
# ### whenever_sets
# Pass optional name=value pairs to the --set argument of whenever.
# Specify these in your deploy.rb as a hash:
#     set :whenever_sets, host: ENV['HOST']
```

**NOTE:** this has been ported from a PR that was originally opened into mina, see: https://github.com/mina-deploy/mina/pull/359

This is a very useful option we have been using in production for 1 1/2 years now, it would be great to no longer have to maintain it in a fork.  😺 