### PR TITLE
remove warnings in new mina

### DIFF
--- a/lib/mina/whenever/tasks.rb
+++ b/lib/mina/whenever/tasks.rb
@@ -2,7 +2,7 @@ set :whenever_name, -> { "#{fetch(:domain)}_#{fetch(:rails_env)}" }
 
 namespace :whenever do
   desc 'Clear crontab'
-  task clear: :environment do
+  task clear: :remote_environment do
     comment "Clear contrab for #{fetch(:whenever_name)}"
     in_path fetch(:current_path) do
       command "#{fetch(:bundle_bin)} exec whenever --clear-crontab #{fetch(:whenever_name)} --set 'environment=#{fetch(:rails_env)}&path=#{fetch(:current_path)}'"
@@ -10,7 +10,7 @@ namespace :whenever do
   end
 
   desc 'Update crontab'
-  task update: :environment do
+  task update: :remote_environment do
     comment "Update crontab for #{fetch(:whenever_name)}"
     in_path fetch(:current_path) do
       command "#{fetch(:bundle_bin)} exec whenever --update-crontab #{fetch(:whenever_name)} --set 'environment=#{fetch(:rails_env)}&path=#{fetch(:current_path)}'"
@@ -18,7 +18,7 @@ namespace :whenever do
   end
 
   desc 'Write crontab'
-  task write: :environment do
+  task write: :remote_environment do
     comment "Write crontab for #{fetch(:whenever_name)}"
     in_path fetch(:current_path) do
       command "#{fetch(:bundle_bin)} exec whenever --write-crontab #{fetch(:whenever_name)} --set 'environment=#{fetch(:rails_env)}&path=#{fetch(:current_path)}'"


### PR DESCRIPTION
New mina requires the environment for each task to be explicitly set as `:local_environment` or `:remote_environment`. Without this, there is an annoying warning when running `mina deploy`. This commit is simply for fixing it